### PR TITLE
Model training api

### DIFF
--- a/TrainingExample.ipynb
+++ b/TrainingExample.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import model.fruit\n",
+    "import torch\n",
+    "import torch.utils.data\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as func\n",
+    "import torchvision\n",
+    "import numpy as np\n",
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Importing the Data Set\n",
+    "\n",
+    "The first step of training or testing is to import your dataset.\n",
+    "This will make the image set available for use, as well as defining your labels.\n",
+    "\n",
+    "Training data must be organized into folders, each of which representing one classification.\n",
+    "For example, a folder called 'Apples' which contains only apple pictures, then a folder called 'Bananas', etc.\n",
+    "\n",
+    "The root path passed into the `get_data()` function should contain all of folders, having the structure:\n",
+    "\n",
+    "```\n",
+    "root/\n",
+    "  Apples/\n",
+    "    img1.jpg\n",
+    "    img2.jpg\n",
+    "    ...\n",
+    "    imgN.jpg\n",
+    "  Bananas/\n",
+    "    img1.jpg\n",
+    "    img2.jpg\n",
+    "    ...\n",
+    "    imgN.jpg\n",
+    "  ...\n",
+    "```\n",
+    "\n",
+    "*Note: importing a dataset is NOT NECESSARY for inference, only for testing and training*"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "['Apple', 'Banana', 'Lemon', 'Limes']"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# To run this example, replace the path below with the path to your dataset.\n",
+    "# It is recommended to import twice, once for training and once for testing (with different data sets, obviously).\n",
+    "\n",
+    "training_set, classes = model.fruit.FruitTrainingModel.get_data(root=r\"D:\\Documents\\School\\MAIN_FRUITS\\PLAY\",\n",
+    "                                                                batch_size=4,\n",
+    "                                                                shuffle=True,\n",
+    "                                                                num_workers=4)\n",
+    "# get_data() returns a dict mapping the label name to its id (an integer).\n",
+    "# For training, we need to convert this into an ordered list of strings.\n",
+    "classes = sorted(list(classes.keys()), key=lambda cls: classes[cls])\n",
+    "classes"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Basic Model Training\n",
+    "\n",
+    "Below is the world's simplest training pipeline, just for basic demonstration.\n",
+    "Typical features of a training pipeline include things like measurements, accuracy tests, convergence, among others.\n",
+    "The given example blindly trains the model, for demonstration purposes.\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [],
+   "source": [
+    "# First, we create our model.\n",
+    "m = model.fruit.FruitTrainingModel(labels=classes)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model...\n",
+      "16 out of 165 sets (avg loss so far = 0.6747409517566363)\n",
+      "32 out of 165 sets (avg loss so far = 0.33392617444042116)\n",
+      "48 out of 165 sets (avg loss so far = 0.13609429344069213)\n",
+      "64 out of 165 sets (avg loss so far = 0.1566448172670789)\n",
+      "80 out of 165 sets (avg loss so far = 0.14235287410701858)\n",
+      "96 out of 165 sets (avg loss so far = 0.1349896158571937)\n",
+      "112 out of 165 sets (avg loss so far = 0.05407547660070122)\n",
+      "128 out of 165 sets (avg loss so far = 0.07990075941233954)\n",
+      "144 out of 165 sets (avg loss so far = 0.0998560030166118)\n",
+      "160 out of 165 sets (avg loss so far = 0.07949153185836622)\n",
+      "Done! Final avg loss:  0.17901555402204394\n"
+     ]
+    }
+   ],
+   "source": [
+    "# World's simplest training pipeline\n",
+    "# WARNING: this will take quite a while, especially with a large dataset.\n",
+    "num_epochs = 8\n",
+    "loss = []\n",
+    "try:\n",
+    "    print(\"Training model...\")\n",
+    "    for i, data in enumerate(training_set, start=1):\n",
+    "        # Every 10% of the way there, give a checkpoint update.\n",
+    "        if i % (len(training_set) // 10) == 0:\n",
+    "            print(f\"{i} out of {len(training_set)} sets (avg loss so far = {np.array(loss).mean()})\")\n",
+    "            loss.clear()\n",
+    "        # Train our model, record the results.\n",
+    "        for j in range(num_epochs):\n",
+    "            loss.append(m.run_epoch(data))\n",
+    "except KeyboardInterrupt:\n",
+    "    print(\"Training was interrupted\")\n",
+    "\n",
+    "# Return the average loss during training\n",
+    "print(\"Done! Final avg loss: \", np.array(loss).mean())"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Inference\n",
+    "\n",
+    "Finally, we can take our trained model and make predictions with it!\n",
+    "\n",
+    "The simplest way is to pass in a PIL image, but you may alternatively pass in a 4D tensor representing the image."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'Banana': 0.7035243511199951}"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "img = Image.open(r\"D:\\Documents\\School\\MAIN_FRUITS\\banana1.jpg\")\n",
+    "# img = model.fruit.FruitModel.transform(img).unsqueeze(0)\n",
+    "m.predict(img)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Importing/Exporting\n",
+    "\n",
+    "Once a model has been satisfactorily trained, you can export it to a `.pth` file to be reloaded later.\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Export Model\n",
+    "\n",
+    "The model state will be saved to the given location and can be loaded later.\n",
+    "It is recommended that these models be versioned, and the labels that they were trained with be recorded."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "m.export(r\"D:\\Documents\\School\\MAIN_FRUITS\\model.pth\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Import Model\n",
+    "\n",
+    "You will need access to the same labels (in the same order) that you exported your model with!\n",
+    "Using different labels will result in odd or broken predictions."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'Banana': 0.7035243511199951}"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mx = model.fruit.FruitModel.from_file(labels=classes, path=r\"D:\\Documents\\School\\MAIN_FRUITS\\model.pth\")\n",
+    "mx.predict(Image.open(r\"D:\\Documents\\School\\MAIN_FRUITS\\banana1.jpg\"))\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/model/fruit.py
+++ b/model/fruit.py
@@ -2,56 +2,108 @@ import torch
 import torch.nn.functional
 import torch.optim as opt
 import torchvision
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, DataLoader
 from torchvision.datasets import ImageFolder
+from PIL import Image
+from typing import Union
 
 
 class FruitModel:
     def __init__(self, labels: "list[str]", model: "torch.nn.Module" = None, threshold=0.6):
         """
-        Wrapper class for PyTorch model prediction and training.
+        Wrapper class for PyTorch model prediction.
+        The model may additionally be instantiated from a .pth file using from_file().
+        Once instantiated, it may be used for classifying images.
 
-        :param model: PyTorch module to predict/train against.
+        :param labels: List of indexed label strings representing the names for each classification.
+        If providing a pre-built model, the labels must match those that the model was trained with.
+        :type labels: list[str]
+
+        :param model: Optional PyTorch module to predict/train against.
+        The project default model will be created automatically if not provided.
+        In most scenarios, there is no need to provide a model (unless you are experimenting with different ResNets).
+        (If you are wanting to use a pre-existing model without experimenting, use from_file() instead)
         :type model: torch.Module
 
-        :param threshold: Value on range (0.0, 1.0] where only predictions which meet the confidence threshold
+        :param threshold: Value on range (0.0, 1.0) where only predictions which meet the confidence threshold
         are considered valid. Any predictions whose confidence scores do not exceed the threshold are
         deemed invalid and are discarded.
         :type threshold: float
 
-        :param labels: Optional list of indexed label strings representing the names for each classification.
-        :type labels: list[str]
+        :raises ValueError: When the number of labels provided does not match the number of model features.
         """
         self._labels = labels
 
         if model is None:
-            model = torchvision.models.resnet50(pretrained=False)
+            model = torchvision.models.resnet50(pretrained=True)
             model.fc = torch.nn.Linear(model.fc.in_features, len(self._labels))
+        elif model.fc.out_features != len(labels):
+            raise ValueError(f"The PyTorch module provided ({model.fc.out_features} features) "
+                             f"does not match the labels provided ({len(labels)} labels)")
         self._model = model.to("cpu")
 
         self.threshold = float(threshold)
 
     @classmethod
-    def get_transform(cls):
+    def get_transform(cls) -> "torchvision.transforms.Compose":
+        """
+        Generate the default PyTorch transformation for converting image data to a normalized tensor.
+
+        :return: Instance of default Torchvision transformation object
+        """
         return torchvision.transforms.Compose([
             torchvision.transforms.Resize(256),
             torchvision.transforms.ToTensor(),
         ])
 
     @classmethod
-    def transform(cls, data):
+    def transform(cls, data: "Image.Image") -> "torch.tensor":
+        """
+        Generate the default PyTorch transformation and apply it against the given image data.
+        Useful for one-off transformations, but if repeated transformations are needed,
+        it is preferable to use get_transform to get a reusable transform function.
+
+        :param data: Image data to apply the default transformation against.
+        :type data: PIL.Image.Image
+
+        :return: Transformed and normalized tensor data based on the provided image.
+        """
         return cls.get_transform()(data)
 
-    def predict(self, img_data: "torch.Tensor") -> "list[tuple[str, float]]":
+    @torch.no_grad()
+    def predict(self, img_data: "Union[torch.Tensor, Image.Image]", limit=True) -> "dict[str, float]":
+        """
+        Determine what classifications the given image belongs to and their probabilities.
+        Either a pre-processed Tensor or PIL image may be provided.
+
+        :param img_data: Image to generate predictions for.
+        A PyTorch tensor is greatly preferred, but a PIL image can use default transformations to pre-process for you.
+        An example of this usage:
+        >>> from PIL import Image
+        >>> model = FruitModel(labels["example1", "example2"])
+        >>> model.predict(Image.open(r"/path/to/image"))
+        <<< dict({ "example1": 0.7 })
+
+        :param limit: Indicate whether or not low-scoring predictions should be filtered out.
+        If set to False, then all possible labels will be returned with their corresponding confidence scores.
+        :type limit: bool
+
+        :return: Dictionary containing all confident classifications and their confidence scores.
+        Any classifications whose confidence scores are below the threshold are filtered out, unless limit=False.
+        """
+        if isinstance(img_data, Image.Image):
+            img_data = FruitModel.transform(img_data).unsqueeze(0)
+
         m = self._model.eval()
-        with torch.no_grad():
-            predictions = m(img_data)
+        predictions = m(img_data)
         probabilities = torch.nn.functional.softmax(predictions, dim=1).squeeze(0)
-        return [
-            (self._labels[label_id], score.item())
+        return {
+            self._labels[label_id]: score.item()
             for label_id, score in enumerate(probabilities)
-            if score.item() > self.threshold
-        ]
+            # Filtering only applied if limit=True.
+            # When limit=False, the condition below is always true and so no items are removed.
+            if not limit or score.item() >= self.threshold
+        }
 
     @classmethod
     def from_file(cls, path: "str", labels: "list[str]", threshold=0.6) -> "FruitModel":
@@ -86,7 +138,29 @@ class FruitModel:
 
 
 class FruitTrainingModel(FruitModel):
-    def __init__(self, model: "torch.nn.Module" = None, threshold=0.6, labels: "list[str]" = None, optimizer=None, loss=None):
+    def __init__(self, model: "torch.nn.Module" = None, threshold=0.6, labels: "list[str]" = None,
+                 optimizer=None, loss=None):
+        """
+        Helper class for model training.
+        Extends from the base FruitModel, and as such may be used for predictions as well as training.
+
+        :param model: Optional pre-existing PyTorch module.
+        Only recommended when experimenting with different PyTorch backbones.
+        :type model: torch.nn.Module
+
+        :param threshold: Cutoff value for an "accurate" prediction.
+        Lower threshold values result in more false positives, while higher values result in more missed predictions.
+        :type threshold: float
+
+        :param labels: Ordered list of classification labels for the model.
+        Indexed by classification ID, i.e. labels[0] should return the label of classification 0.
+        :type labels: list[str]
+
+        :param optimizer: Optional PyTorch optimizer.
+        Only recommended when experimenting with different PyTorch optimizers.
+        :param loss: Optional PyTorch loss function.
+        Only recommended when experimenting with different PyTorch loss functions.
+        """
         super(FruitTrainingModel, self).__init__(labels=labels, model=model, threshold=threshold)
         self._model.train()
 
@@ -117,14 +191,39 @@ class FruitTrainingModel(FruitModel):
 
         :return: Float representing loss value of the iteration.
         """
+        m = self._model.train()
         values, labels = data
         self.__optimizer.zero_grad()
-        result = self._model(values)
+        result = m(values)
         loss = self.__loss(result, labels)
         loss.backward()
         self.__optimizer.step()
         return loss.item()
 
     @classmethod
-    def get_dataset(cls, root: "str") -> "ImageFolder":
-        return ImageFolder(root=root, transform=FruitModel.get_transform())
+    def get_data(cls, root: "str",
+                 transform: "torchvision.transforms.Compose" = None,
+                 **loader_options) -> "tuple[DataLoader, dict[str, int]]":
+        """
+        Dataset import helper using PIL images for training/testing purposes.
+        The classifications of each dataset must match during training, testing, and inference.
+
+        :param root: Root directory where image classification folders are kept.
+        Each sub-folder in the root directory should contain a single image category.
+        The classification names are derived from the name of each folder.
+        (It is highly recommended to use the EXACT same root folder structure for each model version)
+        :type root: str
+
+        :param transform: Optional torchvision transform.
+        If not specified, the default transformer is used.
+        (Option is only useful if experimenting with different transforms)
+        :type transform: torchvision.transforms.Compose
+
+        :param loader_options: Dictionary containing options to pass to the dataloader.
+
+        :return: Pair of type (DataLoader, dict) where the dict maps label names to their corresponding ids.
+        """
+        if transform is None:
+            transform = FruitModel.get_transform()
+        img_set = ImageFolder(root=root, transform=transform)
+        return DataLoader(dataset=img_set, **loader_options), img_set.class_to_idx


### PR DESCRIPTION
* Adds basic `FruitModel` and `FruitTrainingModel` wrapper classes
* Provides usable data import methods, and model import/export
* Provides usable `FruitModel#predict` method, returns a dictionary of label-score pairs, i.e.:

```python
>>> model.predict(img)
<<< { "apple": 0.6 }
>>> list(model.predict(img).keys())
<<< [ "apple" ]
```